### PR TITLE
Update correction.html

### DIFF
--- a/layouts/partials/correction.html
+++ b/layouts/partials/correction.html
@@ -1,7 +1,7 @@
 {{ if (and .File .Site.Params.editLink) }}
 <div>
   <div class="side side-left"><h3>{{ i18n "suggestChanges" }}</h3></div>
-  {{ $filePath := .File.Path }}
+  {{ $filePath := path.Clean .File.Path }}
   {{ $RmdFile := (print .File.Dir .File.BaseFileName ".Rmd") }}
   {{ if (fileExists (print "content/" $RmdFile)) }}
     {{ $filePath = $RmdFile }}


### PR DESCRIPTION
`correction.html` 用来生成在 GitHub 进行修改的链接。

通过查阅参考资料，发现 `.File.Path` 变量储存的文件路径中，其分隔符是跟随系统的。所以，当网站在 Windows 系统上生成时，这个链接中的分隔符是错误的。具体来说，就是会因为 `\` 的存在导致无法在 GitHub 访问到正确的路径，从而出现 404 错误。

> The path separators (slash or backslash) in .File.Path, .File.Dir, and .File.Filename depend on the operating system.
> 
> **See also**: <https://gohugo.io/variables/files/>

为了解决这个问题，需要对 `correction.html` 模板进行修改，用 `path.Clean` 函数将路径转变为 Linux 格式路径。

> `path.Clean` replaces path separators with slashes (`/`) and removes extraneous separators, including trailing separators.